### PR TITLE
Include OpenAPI validation errors in responses

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -55,7 +55,10 @@ async function createHttpServer() {
   // Sorry - app.use checks arity
   // eslint-disable-next-line no-unused-vars
   app.use((err, req, res, next) => {
-    if (err.status) {
+    if (err.errors) {
+      // openapi validation
+      res.status(err.status).send(err.errors)
+    } else if (err.status) {
       res.status(err.status).send({ error: err.status === 401 ? 'Unauthorised' : err.message })
     } else {
       logger.error('Fallback Error %j', err.stack)

--- a/helm/openapi-service-template/Chart.yaml
+++ b/helm/openapi-service-template/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: openapi-service-template
-appVersion: '0.0.1'
+appVersion: '0.0.2'
 description: A Helm chart for openapi-service-template
-version: '0.0.1'
+version: '0.0.2'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/openapi-service-template/values.yaml
+++ b/helm/openapi-service-template/values.yaml
@@ -3,5 +3,5 @@ config:
 image:
   repository: ghcr.io/digicatapult/openapi-service-template
   pullPolicy: IfNotPresent
-  tag: 'v0.0.1'
+  tag: 'v0.0.2'
   pullSecrets: ['ghcr-digicatapult']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/openapi-service-template",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/openapi-service-template",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/openapi-service-template",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Bug: `400` responses for OpenAPI validation were missing the actual errors e.g. 
```
    {
        "path": "imageAttachmentId",
        "errorCode": "minLength.openapi.requestValidation",
        "message": "must NOT have fewer than 36 characters",
        "location": "body"
    }
```

Solution: includes `err.errors` in the response